### PR TITLE
corrected encoding of channel id

### DIFF
--- a/src/main/java/org/red5/server/net/rtmp/RTMPUtils.java
+++ b/src/main/java/org/red5/server/net/rtmp/RTMPUtils.java
@@ -168,7 +168,7 @@ public class RTMPUtils implements Constants {
 	public static void encodeHeaderByte(IoBuffer out, byte headerSize, int channelId) {
 		if (channelId <= 63) {
 			out.put((byte) ((headerSize << 6) + channelId));
-		} else if (channelId <= 320) {
+		} else if (channelId <= 319) {
 			out.put((byte) (headerSize << 6));
 			out.put((byte) (channelId - 64));
 		} else {


### PR DESCRIPTION
If you play and stop many streams while 5 of them play simultaneously (it should do from one connection). It leads to the rtmp client gets badly formed channel id and disconnects from the server. 

When streamId is 29, channelId is 144, so it should be int but not byte.
