### PR TITLE
 - srcType isn't copied when creating outgoing message. Dropping of p…

### DIFF
--- a/src/main/java/org/red5/server/stream/PlayEngine.java
+++ b/src/main/java/org/red5/server/stream/PlayEngine.java
@@ -999,7 +999,11 @@ public final class PlayEngine implements IFilter, IPushableConsumer, IPipeConnec
 				event.setTimestamp(messageIn.getBody().getTimestamp());
 				break;
 		}
-		RTMPMessage messageOut = RTMPMessage.build(event);
+		
+		// Create the RTMP Message to send. Make sure to propagate the source type
+		// so that the connection can decide to drop packets if the connection
+		// is congested for LIVE streams.
+		RTMPMessage messageOut = RTMPMessage.build(event, messageIn.getBody().getSourceType());
 		//get the current timestamp from the message
 		int ts = messageOut.getBody().getTimestamp();
 		if (log.isTraceEnabled()) {


### PR DESCRIPTION
…ackets on congested RTMPConnection relies on the srcType as only LIVE packets are being dropped.
