### PR TITLE
Drop packets on live streams when outgoing traffic is congested

### DIFF
--- a/src/main/java/org/red5/server/net/rtmp/RTMPConnection.java
+++ b/src/main/java/org/red5/server/net/rtmp/RTMPConnection.java
@@ -1446,6 +1446,14 @@ public abstract class RTMPConnection extends BaseConnection implements IStreamCa
 		lastPongReceivedOn.set(now);
 	}
 
+	/**
+	 * Difference between when the last ping was sent and when the last pong was received.
+	 * @return
+	 */
+	public int getLastPingSentAndLastPongReceivedInterval() {
+	       return (int) (lastPingSentOn.get() - lastPongReceivedOn.get());
+	}
+	
 	/** {@inheritDoc} */
 	public int getLastPingTime() {
 		return lastPingRoundTripTime.get();

--- a/src/main/java/org/red5/server/stream/PlayEngine.java
+++ b/src/main/java/org/red5/server/stream/PlayEngine.java
@@ -999,7 +999,11 @@ public final class PlayEngine implements IFilter, IPushableConsumer, IPipeConnec
 				event.setTimestamp(messageIn.getBody().getTimestamp());
 				break;
 		}
-		RTMPMessage messageOut = RTMPMessage.build(event);
+		
+		// Create the RTMP Message to send. Make sure to propagate the source type
+		// so that the connection can decide to drop packets if the connection
+		// is congested for LIVE streams.
+		RTMPMessage messageOut = RTMPMessage.build(event, messageIn.getBody().getSourceType());
 		//get the current timestamp from the message
 		int ts = messageOut.getBody().getTimestamp();
 		if (log.isTraceEnabled()) {


### PR DESCRIPTION
On live streams, we should be able to drop packets if a client has congested or slow connection. By dropping packets, we don't increase the queue where messages are waiting to be sent reducing memory consumption (prevent OOM). Also, when the congestion is temporary, the client will be able to catch up right away since there will be few packets queued up.
