### PR TITLE
 Made RTMPConnection more thread-safe

### DIFF
--- a/src/main/java/org/red5/server/net/rtmp/Channel.java
+++ b/src/main/java/org/red5/server/net/rtmp/Channel.java
@@ -19,6 +19,7 @@
 package org.red5.server.net.rtmp;
 
 import org.apache.mina.core.buffer.IoBuffer;
+import org.red5.server.api.IContext;
 import org.red5.server.api.scope.IScope;
 import org.red5.server.api.stream.IClientStream;
 import org.red5.server.api.stream.IRtmpSampleAccess;
@@ -168,6 +169,14 @@ public class Channel {
 				final PendingCall call = new PendingCall(null, CALL_ON_STATUS, new Object[] { status });
 				if (status.getCode().equals(StatusCodes.NS_PLAY_START)) {
 					IScope scope = connection.getScope();
+					IContext context = null;
+					if (scope == null) {
+						log.warn("scope is null for connection {}", connection);
+					} else if ((context = scope.getContext()) == null) {
+						log.warn("scope context is null for connection {}", connection);
+					} else if (context.getApplicationContext() == null) {
+						log.warn("application context is null for connection {}", connection);
+					}
 					if (scope.getContext().getApplicationContext().containsBean(IRtmpSampleAccess.BEAN_NAME)) {
 						IRtmpSampleAccess sampleAccess = (IRtmpSampleAccess) scope.getContext().getApplicationContext().getBean(IRtmpSampleAccess.BEAN_NAME);
 						boolean videoAccess = sampleAccess.isVideoAllowed(scope);

--- a/src/main/java/org/red5/server/net/rtmp/Channel.java
+++ b/src/main/java/org/red5/server/net/rtmp/Channel.java
@@ -19,7 +19,6 @@
 package org.red5.server.net.rtmp;
 
 import org.apache.mina.core.buffer.IoBuffer;
-import org.red5.server.api.IContext;
 import org.red5.server.api.scope.IScope;
 import org.red5.server.api.stream.IClientStream;
 import org.red5.server.api.stream.IRtmpSampleAccess;
@@ -169,14 +168,6 @@ public class Channel {
 				final PendingCall call = new PendingCall(null, CALL_ON_STATUS, new Object[] { status });
 				if (status.getCode().equals(StatusCodes.NS_PLAY_START)) {
 					IScope scope = connection.getScope();
-					IContext context = null;
-					if (scope == null) {
-						log.warn("scope is null for connection {}", connection);
-					} else if ((context = scope.getContext()) == null) {
-						log.warn("scope context is null for connection {}", connection);
-					} else if (context.getApplicationContext() == null) {
-						log.warn("application context is null for connection {}", connection);
-					}
 					if (scope.getContext().getApplicationContext().containsBean(IRtmpSampleAccess.BEAN_NAME)) {
 						IRtmpSampleAccess sampleAccess = (IRtmpSampleAccess) scope.getContext().getApplicationContext().getBean(IRtmpSampleAccess.BEAN_NAME);
 						boolean videoAccess = sampleAccess.isVideoAllowed(scope);

--- a/src/main/java/org/red5/server/net/rtmp/RTMPConnection.java
+++ b/src/main/java/org/red5/server/net/rtmp/RTMPConnection.java
@@ -798,7 +798,7 @@ public abstract class RTMPConnection extends BaseConnection implements IStreamCa
 	 * @param stream
 	 */
 	private boolean registerStream(IClientStream stream) {
-		if (streams.putIfAbsent(stream.getStreamId() - 1, stream) != null) {
+		if (streams.putIfAbsent(stream.getStreamId() - 1, stream) == null) {
 			usedStreams.incrementAndGet();
 			return true;
 		}

--- a/src/main/java/org/red5/server/net/rtmp/RTMPConnection.java
+++ b/src/main/java/org/red5/server/net/rtmp/RTMPConnection.java
@@ -137,7 +137,7 @@ public abstract class RTMPConnection extends BaseConnection implements IStreamCa
 	/**
 	 * Reserved stream ids. Stream id's directly relate to individual NetStream instances.
 	 */
-	private Set<Integer> reservedStreams = Collections.newSetFromMap(new ConcurrentHashMap<Integer, Boolean>(4, 0.9f, 2));
+	private transient Set<Integer> reservedStreams = Collections.newSetFromMap(new ConcurrentHashMap<Integer, Boolean>(4, 0.9f, 2));
 
 	/**
 	 * Transaction identifier for remote commands.

--- a/src/main/java/org/red5/server/net/rtmp/RTMPConnection.java
+++ b/src/main/java/org/red5/server/net/rtmp/RTMPConnection.java
@@ -591,9 +591,9 @@ public abstract class RTMPConnection extends BaseConnection implements IStreamCa
 		int result = -1;
 		for (int i = 0; true; i++) {
 			if (reservedStreams.add(i)) {
-                result = i;
+				result = i;
 				break;
-            }
+			}
 		}
 		return result + 1;
 	}

--- a/src/main/java/org/red5/server/stream/PlaylistSubscriberStream.java
+++ b/src/main/java/org/red5/server/stream/PlaylistSubscriberStream.java
@@ -190,7 +190,7 @@ public class PlaylistSubscriberStream extends AbstractClientStream implements IP
 
 				engine = new PlayEngine.Builder(this, schedulingService, consumerService, providerService).build();
 			} else {
-				log.info("Scope was null on start");
+				throw new IllegalStateException("Scope was null on start playing");
 			}
 		}
 		//set buffer check interval


### PR DESCRIPTION
I got a lot of exceptions like this:

```
2015-08-18 16:59:15,077 [RTMPConnectionExecutor-2] ERROR o.r.server.service.ServiceInvoker - Error executing call: Service: null Method: play Num Params: 1 0: TELLE15.flv
java.lang.reflect.InvocationTargetException: null
        at sun.reflect.GeneratedMethodAccessor44.invoke(Unknown Source) ~[na:na]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.7.0_79]
        at java.lang.reflect.Method.invoke(Method.java:606) ~[na:1.7.0_79]
        at org.red5.server.service.ServiceInvoker.invoke(ServiceInvoker.java:193) ~[red5-server-common-1.0.6-SNAPSHOT.jar:na]
        at org.red5.server.net.rtmp.RTMPHandler.invokeCall(RTMPHandler.java:210) [red5-server-common-1.0.6-SNAPSHOT.jar:1.0.6-SNAPSHOT]
        at org.red5.server.net.rtmp.RTMPHandler.onCommand(RTMPHandler.java:269) [red5-server-common-1.0.6-SNAPSHOT.jar:1.0.6-SNAPSHOT]
        at org.red5.server.net.rtmp.BaseRTMPHandler.messageReceived(BaseRTMPHandler.java:105) [red5-server-common-1.0.6-SNAPSHOT.jar:1.0.6-SNAPSHOT]
        at org.red5.server.net.rtmp.ReceivedMessageTask.call(ReceivedMessageTask.java:63) [red5-server-common-1.0.6-SNAPSHOT.jar:1.0.6-SNAPSHOT]
        at org.red5.server.net.rtmp.ReceivedMessageTask.call(ReceivedMessageTask.java:14) [red5-server-common-1.0.6-SNAPSHOT.jar:1.0.6-SNAPSHOT]
        at java.util.concurrent.FutureTask.run(FutureTask.java:262) [na:1.7.0_79]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471) [na:1.7.0_79]
        at java.util.concurrent.FutureTask.run(FutureTask.java:262) [na:1.7.0_79]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145) [na:1.7.0_79]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615) [na:1.7.0_79]
        at java.lang.Thread.run(Thread.java:745) [na:1.7.0_79]
Caused by: java.lang.NullPointerException: null
        at org.red5.server.stream.PlaylistSubscriberStream.stop(PlaylistSubscriberStream.java:267) ~[red5-server-common-1.0.6-SNAPSHOT.jar:1.0.6-SNAPSHOT]
        at org.red5.server.stream.PlaylistSubscriberStream.removeAllItems(PlaylistSubscriberStream.java:346) ~[red5-server-common-1.0.6-SNAPSHOT.jar:1.0.6-SNAPSHOT]
        at org.red5.server.stream.StreamService.play(StreamService.java:322) ~[red5-server-common-1.0.6-SNAPSHOT.jar:1.0.6-SNAPSHOT]
        at org.red5.server.stream.StreamService.play(StreamService.java:360) ~[red5-server-common-1.0.6-SNAPSHOT.jar:1.0.6-SNAPSHOT]
        ... 15 common frames omitted
```

It is occurred because we can create new streams concurrently. So I changed BitSet to concurrent HashSet. Also I reorganized code a little bit. I increased concurrency level for channels, streams and other maps so we could work with this maps concurrently.
