### PR TITLE
  Made a processing of messages in one channel sequentially

### DIFF
--- a/src/main/java/org/red5/server/net/rtmp/IReceivedMessageTaskQueueListener.java
+++ b/src/main/java/org/red5/server/net/rtmp/IReceivedMessageTaskQueueListener.java
@@ -1,0 +1,6 @@
+package org.red5.server.net.rtmp;
+
+public interface IReceivedMessageTaskQueueListener
+{
+	void onTaskQueueChanged(ReceivedMessageTaskQueue queue);
+}

--- a/src/main/java/org/red5/server/net/rtmp/IReceivedMessageTaskQueueListener.java
+++ b/src/main/java/org/red5/server/net/rtmp/IReceivedMessageTaskQueueListener.java
@@ -1,6 +1,25 @@
+/*
+ * RED5 Open Source Flash Server - https://github.com/Red5/
+ *
+ * Copyright 2006-2015 by respective authors (see below). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.red5.server.net.rtmp;
 
 public interface IReceivedMessageTaskQueueListener
 {
-	void onTaskQueueChanged(ReceivedMessageTaskQueue queue);
+	void onTaskAdded(ReceivedMessageTaskQueue queue);
+	void onTaskRemoved(ReceivedMessageTaskQueue queue);
 }

--- a/src/main/java/org/red5/server/net/rtmp/RTMPConnection.java
+++ b/src/main/java/org/red5/server/net/rtmp/RTMPConnection.java
@@ -91,8 +91,7 @@ import org.springframework.util.concurrent.ListenableFutureTask;
 /**
  * RTMP connection. Stores information about client streams, data transfer channels, pending RPC calls, bandwidth configuration, AMF encoding type (AMF0/AMF3), connection state (is alive, last ping time and ping result) and session.
  */
-public abstract class RTMPConnection extends BaseConnection implements IStreamCapableConnection,
-		IServiceCapableConnection, IReceivedMessageTaskQueueListener {
+public abstract class RTMPConnection extends BaseConnection implements IStreamCapableConnection, IServiceCapableConnection, IReceivedMessageTaskQueueListener {
 
 	private static Logger log = LoggerFactory.getLogger(RTMPConnection.class);
 
@@ -168,9 +167,11 @@ public abstract class RTMPConnection extends BaseConnection implements IStreamCa
 	private transient ConcurrentMap<Integer, Channel> channels = new ConcurrentHashMap<Integer, Channel>(channelsInitalCapacity, 0.9f, channelsConcurrencyLevel);
 
 	/**
-	 * Tasks queues for every channel
+	 * Queues of tasks for every channel 
+	 *
+	 * @see org.red5.server.net.rtmp.ReceivedMessageTaskQueue
 	 */
-	private final transient ConcurrentMap<Integer, ReceivedMessageTaskQueue> tasksByChannels = new ConcurrentHashMap<Integer, ReceivedMessageTaskQueue>(3, 0.9f, 1);
+	private final transient ConcurrentMap<Integer, ReceivedMessageTaskQueue> tasksByChannels = new ConcurrentHashMap<Integer, ReceivedMessageTaskQueue>(channelsInitalCapacity, 0.9f, channelsConcurrencyLevel);
 
 	/**
 	 * Client streams
@@ -606,15 +607,9 @@ public abstract class RTMPConnection extends BaseConnection implements IStreamCa
 	 * @return Channel by id
 	 */
 	public Channel getChannel(int channelId) {
-		if (log.isTraceEnabled()) {
-			log.trace("Trying to get channel for channelId {}; channels: {}", channelId, channels);
-		}
 		if (channels != null) {
 			Channel channel = channels.putIfAbsent(channelId, new Channel(this, channelId));
 			if (channel == null) {
-				if (log.isTraceEnabled()) {
-					log.trace("Channel has just added for channelId {}; channels: {}", channelId, channels);
-				}
 				channel = channels.get(channelId);
 			}
 			return channel;

--- a/src/main/java/org/red5/server/net/rtmp/ReceivedMessageTask.java
+++ b/src/main/java/org/red5/server/net/rtmp/ReceivedMessageTask.java
@@ -101,8 +101,16 @@ public final class ReceivedMessageTask implements Callable<Packet> {
 		return packet;
 	}
 
+	public long getPacketNumber() {
+		return packetNumber;
+	}
+
 	public void setPacketNumber(long packetNumber) {
 		this.packetNumber = packetNumber;
+	}
+
+	public Packet getPacket() {
+		return packet;
 	}
 
 	/**

--- a/src/main/java/org/red5/server/net/rtmp/ReceivedMessageTask.java
+++ b/src/main/java/org/red5/server/net/rtmp/ReceivedMessageTask.java
@@ -51,6 +51,10 @@ public final class ReceivedMessageTask implements Callable<Packet> {
 
 	private final AtomicBoolean processing = new AtomicBoolean(false);
 
+	private Thread taskThread;
+
+	private ScheduledFuture<Runnable> deadlockFuture;
+
 	public ReceivedMessageTask(String sessionId, Packet packet, IRTMPHandler handler) {
 		this(sessionId, packet, handler, (RTMPConnection) RTMPConnManager.getInstance().getConnectionBySessionId(sessionId));
 	}
@@ -64,36 +68,15 @@ public final class ReceivedMessageTask implements Callable<Packet> {
 
 	@SuppressWarnings("unchecked")
     public Packet call() throws Exception {
-		// keep a ref here for deadlockguard
-		ScheduledFuture<Runnable> deadlockFuture = null;
+		//keep a ref for executor thread
+		taskThread = Thread.currentThread();
 		// set connection to thread local
 		Red5.setConnectionLocal(conn);
 		try {
-			// don't run the deadlock guard if timeout is <= 0
-			if (packet.getExpirationTime() > 0L) {
-				// run a deadlock guard so hanging tasks will be interrupted
-				ThreadPoolTaskScheduler deadlockGuard = conn.getDeadlockGuardScheduler();
-				if (deadlockGuard != null) {
-					if (log.isDebugEnabled()) {
-						log.debug("Creating deadlock guard from: {} for: {}", Thread.currentThread().getName(), sessionId);
-					}
-					try {
-						deadlockFuture = (ScheduledFuture<Runnable>) deadlockGuard.schedule(new DeadlockGuard(Thread.currentThread()), new Date(packet.getExpirationTime()));
-					} catch (TaskRejectedException e) {
-						log.warn("DeadlockGuard task is rejected for {}", sessionId, e);
-					}
-				} else {
-					log.error("Deadlock guard is null for {}", sessionId);
-				}
-			}
 			// pass message to the handler
 			handler.messageReceived(conn, packet);
 			// if we get this far, set done / completed flag
 			packet.setProcessed(true);
-			// kill the future for the deadlock since processing is complete
-			if (deadlockFuture != null) {
-				deadlockFuture.cancel(true);
-			}
 		} finally {
 			// clear thread local
 			Red5.setConnectionLocal(null);
@@ -102,6 +85,50 @@ public final class ReceivedMessageTask implements Callable<Packet> {
 			log.debug("Processing message for {} is processed: {} packet #{}", sessionId, packet.isProcessed(), packetNumber);
 		}
 		return packet;
+	}
+
+	/**
+	 * Creates and runs deadlock guard task
+	 *
+	 * @param deadlockGuardTask
+	 */
+	public void runDeadlockFuture(Runnable deadlockGuardTask) {
+		if (deadlockFuture == null) {
+			ThreadPoolTaskScheduler deadlockGuard = conn.getDeadlockGuardScheduler();
+			if (deadlockGuard != null) {
+				if (log.isDebugEnabled()) {
+					log.debug("Creating deadlock guard from: {} for: {}", Thread.currentThread().getName(), sessionId);
+				}
+				try {
+					deadlockFuture = (ScheduledFuture<Runnable>) deadlockGuard.schedule(deadlockGuardTask, new Date(packet.getExpirationTime()));
+				} catch (TaskRejectedException e) {
+					log.warn("DeadlockGuard task is rejected for {}", sessionId, e);
+				}
+			} else {
+				log.error("Deadlock guard is null for {}", sessionId);
+			}
+		} else {
+			log.error("Deadlock future is already create for {}", sessionId);
+		}
+	}
+
+	/**
+	 * Cancels deadlock future if it was created
+	 */
+	public void cancelDeadlockFuture() {
+		// kill the future for the deadlock since processing is complete
+		if (deadlockFuture != null) {
+			deadlockFuture.cancel(true);
+		}
+	}
+
+	/**
+	 * Marks task as processing if it is not prosessing yet.
+	 *
+	 * @return true if successful, or false otherwise
+	 */
+	public boolean setProcessing() {
+		return processing.compareAndSet(false, true);
 	}
 
 	public long getPacketNumber() {
@@ -116,55 +143,13 @@ public final class ReceivedMessageTask implements Callable<Packet> {
 		return packet;
 	}
 
-	public boolean process() {
-		return processing.compareAndSet(false, true);
+	public Thread getTaskThread() {
+		return taskThread;
 	}
 
-	/**
-	 * Prevents deadlocked message handling.
-	 */
-	private class DeadlockGuard implements Runnable {
-
-		// executor task thread
-		private final Thread taskThread;
-
-		/**
-		 * Creates the deadlock guard to prevent a message task from taking too long to process.
-		 * 
-		 * @param thread
-		 */
-		private DeadlockGuard(Thread taskThread) {
-			// executor thread ref
-			this.taskThread = taskThread;
-			if (log.isTraceEnabled()) {
-				log.trace("DeadlockGuard is created for {}", sessionId);
-			}
-		}
-
-		/**
-		 * Save the reference to the thread, and wait until the maxHandlingTimeout has elapsed. If it elapsed, kill the other thread.
-		 * */
-		public void run() {
-			if (log.isTraceEnabled()) {
-				log.trace("DeadlockGuard is started for {}", sessionId);
-			}
-			// skip processed packet
-			if (packet.isProcessed()) {
-				log.debug("DeadlockGuard skipping processed packet #{} on {}", packetNumber, sessionId);
-			} else if (packet.isExpired()) {
-				log.debug("DeadlockGuard skipping expired packet #{} on {}", packetNumber, sessionId);
-			} else {
-				// if the message task is not yet done or is not expired interrupt
-				// if the task thread hasn't been interrupted check its live-ness
-				// if the task thread is alive, interrupt it
-				if (!taskThread.isInterrupted() && taskThread.isAlive()) {
-					log.warn("Interrupting unfinished active task for packet #{} on {}", packetNumber, sessionId);
-					taskThread.interrupt();
-				} else {
-					log.debug("Unfinished active task for {} already interrupted packet #{} ", sessionId, packetNumber);
-				}
-			}
-		}
+	@Override
+	public String toString() {
+		return "[sessionId: " + sessionId + "; packetNumber: " + packetNumber + "; processing: " + processing.get() + "]";
 	}
-
+	
 }

--- a/src/main/java/org/red5/server/net/rtmp/ReceivedMessageTask.java
+++ b/src/main/java/org/red5/server/net/rtmp/ReceivedMessageTask.java
@@ -21,6 +21,7 @@ package org.red5.server.net.rtmp;
 import java.util.Date;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.red5.server.api.Red5;
 import org.red5.server.net.rtmp.message.Packet;
@@ -47,6 +48,8 @@ public final class ReceivedMessageTask implements Callable<Packet> {
 	private Packet packet;
 
 	private long packetNumber;
+
+	private final AtomicBoolean processing = new AtomicBoolean(false);
 
 	public ReceivedMessageTask(String sessionId, Packet packet, IRTMPHandler handler) {
 		this(sessionId, packet, handler, (RTMPConnection) RTMPConnManager.getInstance().getConnectionBySessionId(sessionId));
@@ -111,6 +114,10 @@ public final class ReceivedMessageTask implements Callable<Packet> {
 
 	public Packet getPacket() {
 		return packet;
+	}
+
+	public boolean process() {
+		return processing.compareAndSet(false, true);
 	}
 
 	/**

--- a/src/main/java/org/red5/server/net/rtmp/ReceivedMessageTask.java
+++ b/src/main/java/org/red5/server/net/rtmp/ReceivedMessageTask.java
@@ -88,16 +88,16 @@ public final class ReceivedMessageTask implements Callable<Packet> {
 	}
 
 	/**
-	 * Creates and runs deadlock guard task
+	 * Runs deadlock guard task
 	 *
-	 * @param deadlockGuardTask
+	 * @param deadlockGuardTask deadlock guard task
 	 */
 	public void runDeadlockFuture(Runnable deadlockGuardTask) {
 		if (deadlockFuture == null) {
 			ThreadPoolTaskScheduler deadlockGuard = conn.getDeadlockGuardScheduler();
 			if (deadlockGuard != null) {
 				if (log.isDebugEnabled()) {
-					log.debug("Creating deadlock guard from: {} for: {}", Thread.currentThread().getName(), sessionId);
+					log.debug("Creating deadlock guard for: {}", this);
 				}
 				try {
 					deadlockFuture = (ScheduledFuture<Runnable>) deadlockGuard.schedule(deadlockGuardTask, new Date(packet.getExpirationTime()));

--- a/src/main/java/org/red5/server/net/rtmp/ReceivedMessageTaskQueue.java
+++ b/src/main/java/org/red5/server/net/rtmp/ReceivedMessageTaskQueue.java
@@ -145,7 +145,7 @@ public class ReceivedMessageTaskQueue {
 			if (packet.isProcessed()) {
 				log.debug("DeadlockGuard skipping task for processed packet {}", task);
 			} else if (packet.isExpired()) {
-				//I believe we also should try to interrup thread
+				//I believe we also should try to interrupt thread
 				log.debug("DeadlockGuard skipping task for expired packet {}", task);
 			} else {
 				// if the message task is not yet done or is not expired interrupt

--- a/src/main/java/org/red5/server/net/rtmp/ReceivedMessageTaskQueue.java
+++ b/src/main/java/org/red5/server/net/rtmp/ReceivedMessageTaskQueue.java
@@ -20,13 +20,14 @@ package org.red5.server.net.rtmp;
 
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
+
 import org.red5.server.net.rtmp.message.Packet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Contains queue of tasks for processing messages in specified channel.
- * All messages which has got in channel must be processed sequentially.
+ * Contains queue of tasks for processing messages in the specified channel.
+ * Ensures that all messages which has got in channel will be processed sequentially.
  *
  * @author Maria Chabanets (m.e.platova@gmail.com)
  */
@@ -35,29 +36,29 @@ public class ReceivedMessageTaskQueue {
 	private final static Logger log = LoggerFactory.getLogger(ReceivedMessageTaskQueue.class);
 
 	/**
-	 * Channel id
+	 * Channel id.
 	 */
 	private final int channelId;
 
 	/**
-	 * Tasks queue
+	 * Task queue.
 	 */
 	private final Queue<ReceivedMessageTask> tasks = new ConcurrentLinkedQueue<ReceivedMessageTask>();
 
 	/**
-	 * Listener that try to process message from queue if queue has changed
+	 * Listener which tries to process message from queue if queue has been changed.
 	 */
 	private final IReceivedMessageTaskQueueListener listener;
 
 	public ReceivedMessageTaskQueue(int channelId, IReceivedMessageTaskQueueListener listener) {
-		this.listener = listener;
 		this.channelId = channelId;
+		this.listener = listener;
 	}
 
 	/**
-	 * Adds new task to the end of queue.
+	 * Adds new task to the end of the queue.
 	 *
-	 * @param task
+	 * @param task received message task
 	 */
 	public void addTask(ReceivedMessageTask task) {
 		tasks.add(task);
@@ -75,7 +76,7 @@ public class ReceivedMessageTaskQueue {
 	/**
 	 * Removes the specified task from the queue.
 	 *
-	 * @param task
+	 * @param task received message task
 	 */
 	public void removeTask(ReceivedMessageTask task) {
 		if (tasks.remove(task)) {
@@ -101,7 +102,7 @@ public class ReceivedMessageTaskQueue {
 	}
 
 	/**
-	 * Removes all tasks from queue.
+	 * Removes all tasks from the queue.
 	 */
 	public void removeAllTasks() {
 		for (ReceivedMessageTask task : tasks) {
@@ -161,7 +162,7 @@ public class ReceivedMessageTaskQueue {
 					log.debug("Unfinished task {} already interrupted", task);
 				}
 			}
-			//remove this task from queue in any case
+			//remove this task from the queue in any case
 			removeTask(task);
 		}
 	}

--- a/src/main/java/org/red5/server/net/rtmp/ReceivedMessageTaskQueue.java
+++ b/src/main/java/org/red5/server/net/rtmp/ReceivedMessageTaskQueue.java
@@ -1,0 +1,51 @@
+package org.red5.server.net.rtmp;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class ReceivedMessageTaskQueue {
+	/**
+	 * Tasks queue
+	 */
+	private final Queue<ReceivedMessageTask> tasks = new ConcurrentLinkedQueue<ReceivedMessageTask>();
+
+	/**
+	 * FIXME
+	 */
+	private final AtomicBoolean processing = new AtomicBoolean(false);
+
+	/**
+	 * FIXME Changes processing flag atomically
+	 *
+	 * @param processing
+	 * @return
+	 */
+	public boolean changeProcessing(boolean processing) {
+		return this.processing.compareAndSet(!processing, processing);
+	}
+
+	/**
+	 * FIXME
+	 * @param task
+	 */
+	public void addTask(ReceivedMessageTask task) {
+		tasks.add(task);
+	}
+
+
+	/**
+	 * FIXME
+	 * @return
+	 */
+	public ReceivedMessageTask pollTask() {
+		return tasks.poll();
+	}
+
+	/**
+	 * FIXME
+	 */
+	public void removeAllTasks() {
+		tasks.clear();
+	}
+}

--- a/src/main/java/org/red5/server/net/rtmp/ReceivedMessageTaskQueue.java
+++ b/src/main/java/org/red5/server/net/rtmp/ReceivedMessageTaskQueue.java
@@ -1,23 +1,53 @@
+/*
+ * RED5 Open Source Flash Server - https://github.com/Red5/
+ *
+ * Copyright 2006-2015 by respective authors (see below). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.red5.server.net.rtmp;
 
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import org.red5.server.net.rtmp.message.Packet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+/**
+ * Contains queue of tasks for processing messages in specified channel.
+ * All messages which has got in channel must be processed sequentially.
+ *
+ * @author Maria Chabanets (m.e.platova@gmail.com)
+ */
 public class ReceivedMessageTaskQueue {
+
+	private final static Logger log = LoggerFactory.getLogger(ReceivedMessageTaskQueue.class);
+
+	/**
+	 * Channel id
+	 */
+	private final int channelId;
+
 	/**
 	 * Tasks queue
 	 */
 	private final Queue<ReceivedMessageTask> tasks = new ConcurrentLinkedQueue<ReceivedMessageTask>();
 
 	/**
-	 * Listener
+	 * Listener that try to process message from queue if queue has changed
 	 */
 	private final IReceivedMessageTaskQueueListener listener;
-
-	/**
-	 * Channel id
-	 */
-	private final int channelId;
 
 	public ReceivedMessageTaskQueue(int channelId, IReceivedMessageTaskQueueListener listener) {
 		this.listener = listener;
@@ -25,34 +55,45 @@ public class ReceivedMessageTaskQueue {
 	}
 
 	/**
-	 * FIXME
+	 * Adds new task to the end of queue.
+	 *
 	 * @param task
 	 */
 	public void addTask(ReceivedMessageTask task) {
 		tasks.add(task);
+		Packet packet = task.getPacket();
+		// don't run the deadlock guard if timeout is <= 0
+		if (packet.getExpirationTime() > 0L) {
+			// run a deadlock guard so hanging tasks will be interrupted
+			task.runDeadlockFuture(new DeadlockGuard(task));
+		}
 		if (listener != null) {
-			listener.onTaskQueueChanged(this);
+			listener.onTaskAdded(this);
 		}
 	}
 
 	/**
-	 * FIXME
+	 * Removes the specified task from the queue.
 	 *
 	 * @param task
 	 */
 	public void removeTask(ReceivedMessageTask task) {
-		if (tasks.remove(task) && listener != null) {
-			listener.onTaskQueueChanged(this);
+		if (tasks.remove(task)) {
+			task.cancelDeadlockFuture();
+			if (listener != null) {
+				listener.onTaskRemoved(this);
+			}
 		}
 	}
 
 	/**
-	 * FIXME
-	 * @return
+	 * Gets first task from queue if it can be processed. If first task is already in process it returns null.
+	 *
+	 * @return task that can be processed or null otherwise
 	 */
 	public ReceivedMessageTask getTaskToProcess() {
 		ReceivedMessageTask task = tasks.peek();
-		if (task != null && task.process()) {
+		if (task != null && task.setProcessing()) {
 			return task;
 		}
 
@@ -60,13 +101,68 @@ public class ReceivedMessageTaskQueue {
 	}
 
 	/**
-	 * FIXME
+	 * Removes all tasks from queue.
 	 */
 	public void removeAllTasks() {
+		for (ReceivedMessageTask task : tasks) {
+			task.cancelDeadlockFuture();
+		}
 		tasks.clear();
 	}
 
 	public int getChannelId() {
 		return channelId;
+	}
+
+	/**
+	 * Prevents deadlocked message handling.
+	 */
+	private class DeadlockGuard implements Runnable {
+
+		private final ReceivedMessageTask task;
+
+		/**
+		 * Creates the deadlock guard to prevent a message task from taking too long to setProcessing.
+		 *
+		 * @param task
+		 */
+		private DeadlockGuard(ReceivedMessageTask task) {
+			this.task = task;
+			if (log.isTraceEnabled()) {
+				log.trace("DeadlockGuard is created for {}", task);
+			}
+		}
+
+		/**
+		 * Save the reference to the task, and wait until the maxHandlingTimeout has elapsed. If it elapsed, remove task and stop its thread.
+		 * */
+		public void run() {
+			Packet packet = task.getPacket();
+			if (log.isTraceEnabled()) {
+				log.trace("DeadlockGuard is started for {}", task);
+			}
+			// skip processed packet
+			if (packet.isProcessed()) {
+				log.debug("DeadlockGuard skipping task for processed packet {}", task);
+			} else if (packet.isExpired()) {
+				//I believe we also should try to interrup thread
+				log.debug("DeadlockGuard skipping task for expired packet {}", task);
+			} else {
+				// if the message task is not yet done or is not expired interrupt
+				// if the task thread hasn't been interrupted check its live-ness
+				// if the task thread is alive, interrupt it
+				Thread taskThread = task.getTaskThread();
+				if (taskThread == null) {
+					log.debug("Task has not start yet {}", task);
+				} else if (!taskThread.isInterrupted() && taskThread.isAlive()) {
+					log.warn("Interrupting unfinished active task {}", task);
+					taskThread.interrupt();
+				} else {
+					log.debug("Unfinished task {} already interrupted", task);
+				}
+			}
+			//remove this task from queue in any case
+			removeTask(task);
+		}
 	}
 }


### PR DESCRIPTION
Due to [this pull request](https://github.com/Red5/red5-server-common/pull/12) rtmp-packets within single connection started to be processed concurrently because new executor started to use few threads instead of one.
So we got at least following issue that was occurring because `play` and `receiveAudio` were being processed concurrently:

```
2015-08-11 11:53:12,296 [RTMPConnectionExecutor-5] ERROR o.r.server.service.ServiceInvoker - Error executing call: Service: null Method: receiveAudio Num Params: 1 0: false
java.lang.reflect.InvocationTargetException: null
        at sun.reflect.GeneratedMethodAccessor61.invoke(Unknown Source) ~[na:na]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.7.0_79]
        at java.lang.reflect.Method.invoke(Method.java:606) ~[na:1.7.0_79]
        at org.red5.server.service.ServiceInvoker.invoke(ServiceInvoker.java:193) ~[red5-server-common-1.0.6-SNAPSHOT.jar:na]
        at org.red5.server.net.rtmp.RTMPHandler.invokeCall(RTMPHandler.java:210) [red5-server-common-1.0.6-SNAPSHOT.jar:1.0.6-SNAPSHOT]
        at org.red5.server.net.rtmp.RTMPHandler.onCommand(RTMPHandler.java:269) [red5-server-common-1.0.6-SNAPSHOT.jar:1.0.6-SNAPSHOT]
        at org.red5.server.net.rtmp.BaseRTMPHandler.messageReceived(BaseRTMPHandler.java:105) [red5-server-common-1.0.6-SNAPSHOT.jar:1.0.6-SNAPSHOT]
        at org.red5.server.net.rtmp.ReceivedMessageTask.call(ReceivedMessageTask.java:63) [red5-server-common-1.0.6-SNAPSHOT.jar:1.0.6-SNAPSHOT]
        at org.red5.server.net.rtmp.ReceivedMessageTask.call(ReceivedMessageTask.java:14) [red5-server-common-1.0.6-SNAPSHOT.jar:1.0.6-SNAPSHOT]
        at java.util.concurrent.FutureTask.run(FutureTask.java:262) [na:1.7.0_79]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471) [na:1.7.0_79]
        at java.util.concurrent.FutureTask.run(FutureTask.java:262) [na:1.7.0_79]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145) [na:1.7.0_79]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615) [na:1.7.0_79]
        at java.lang.Thread.run(Thread.java:745) [na:1.7.0_79]
Caused by: java.lang.NullPointerException: null
```

Messages from different channels can be processing concurrently, but all messages in the single channel should be processing sequentially. So I have made following changes:
- In RTMPConnection class there was added a map for queues of tasks for every channel. When message has been received it is placed to the queue for current channel. When message has been processed it is removed from the queue. When channel has been closed all messages from queue are removed.
- Queue is a new class ReceivedMessageTaskQueue. It has inner queue and reference to channel identifier. When inner queue has been changed it notifies about it the listener.
- DeadlockGuard launch has been moved from ReceivedMessageTask to ReceivedMessageTaskQueue in order to have able to remove task from queue even if it has not started processing yet.
- Initial capacity and concurrency level for tasksByChannels are the same as channels because they must be have equal sizes.

I suppose this code requires reworking and I would like you to review it and make your comments. Thank you in advance.
