### PR TITLE
Fix another NPE when transaction id is absent

### DIFF
--- a/src/main/java/org/red5/server/net/rtmp/codec/RTMPProtocolDecoder.java
+++ b/src/main/java/org/red5/server/net/rtmp/codec/RTMPProtocolDecoder.java
@@ -772,8 +772,7 @@ public class RTMPProtocolDecoder implements Constants, IEventDecoder {
         // instance the invoke
         Invoke invoke = new Invoke();
         // set the transaction id
-        Number transactionId = Deserializer.<Number> deserialize(input, Number.class);
-        invoke.setTransactionId(transactionId == null ? 0 : transactionId.intValue());
+        invoke.setTransactionId(readTransactionId(input));
         // reset and decode parameters
         input.reset();
         // get / set the parameters if there any
@@ -795,6 +794,11 @@ public class RTMPProtocolDecoder implements Constants, IEventDecoder {
         invoke.setCall(call);
         return invoke;
     }
+
+	private int readTransactionId(Input input) {
+		Number transactionId = Deserializer.<Number> deserialize(input, Number.class);
+        return transactionId == null ? 0 : transactionId.intValue();
+	}
 
     /**
      * Decodes ping event.
@@ -1017,9 +1021,8 @@ public class RTMPProtocolDecoder implements Constants, IEventDecoder {
         org.red5.io.amf3.Input.RefStorage refStorage = new org.red5.io.amf3.Input.RefStorage();
         Input input = new org.red5.io.amf.Input(in);
         String action = Deserializer.deserialize(input, String.class);
-        int transactionId = Deserializer.<Number> deserialize(input, Number.class).intValue();
         FlexMessage msg = new FlexMessage();
-        msg.setTransactionId(transactionId);
+		msg.setTransactionId(readTransactionId(input));
         Object[] params = new Object[] {};
         if (in.hasRemaining()) {
             ArrayList<Object> paramList = new ArrayList<>();

--- a/src/main/java/org/red5/server/net/rtmp/codec/RTMPProtocolDecoder.java
+++ b/src/main/java/org/red5/server/net/rtmp/codec/RTMPProtocolDecoder.java
@@ -795,10 +795,10 @@ public class RTMPProtocolDecoder implements Constants, IEventDecoder {
         return invoke;
     }
 
-	private int readTransactionId(Input input) {
-		Number transactionId = Deserializer.<Number> deserialize(input, Number.class);
+    private int readTransactionId(Input input) {
+        Number transactionId = Deserializer.<Number> deserialize(input, Number.class);
         return transactionId == null ? 0 : transactionId.intValue();
-	}
+    }
 
     /**
      * Decodes ping event.
@@ -1022,7 +1022,7 @@ public class RTMPProtocolDecoder implements Constants, IEventDecoder {
         Input input = new org.red5.io.amf.Input(in);
         String action = Deserializer.deserialize(input, String.class);
         FlexMessage msg = new FlexMessage();
-		msg.setTransactionId(readTransactionId(input));
+        msg.setTransactionId(readTransactionId(input));
         Object[] params = new Object[] {};
         if (in.hasRemaining()) {
             ArrayList<Object> paramList = new ArrayList<>();


### PR DESCRIPTION
RTMPProtocolDecoder: support absent transaction id in decodeFlexMessage as well.