### PR TITLE
 use only one executor to write packets to file

### DIFF
--- a/src/main/java/org/red5/server/stream/consumer/FileConsumer.java
+++ b/src/main/java/org/red5/server/stream/consumer/FileConsumer.java
@@ -57,7 +57,7 @@ public class FileConsumer implements Constants, IPushableConsumer, IPipeConnecti
     /**
      * Executor for all instance writer jobs
      */
-    private ExecutorService executor = Executors.newFixedThreadPool(2);
+    private ExecutorService executor = Executors.newFixedThreadPool(1);
 
     private static QueuedMediaDataComparator comparator = new QueuedMediaDataComparator();
 


### PR DESCRIPTION
Use only one executor to make sure packets are written in correct order. Otherwise, the video will flicker or have artifacts during playback.