### PR TITLE
Workaround for negative timestamp misinterpretation

### DIFF
--- a/src/main/java/org/red5/server/stream/consumer/ConnectionConsumer.java
+++ b/src/main/java/org/red5/server/stream/consumer/ConnectionConsumer.java
@@ -144,8 +144,9 @@ public class ConnectionConsumer implements IPushableConsumer, IPipeConnectionLis
             int eventTime = msg.getTimestamp();
             log.debug("Message timestamp: {}", eventTime);
             if (eventTime < 0) {
-                log.debug("Message has negative timestamp: {}", eventTime);
-                return;
+                eventTime += Integer.MIN_VALUE;
+                msg.setTimestamp(eventTime);
+                log.debug("Message has negative timestamp, applying {} offset: {}", Integer.MIN_VALUE, eventTime);
             }
             // get the data type
             byte dataType = msg.getDataType();

--- a/src/test/java/org/red5/server/stream/consumer/TestConnectionConsumer.java
+++ b/src/test/java/org/red5/server/stream/consumer/TestConnectionConsumer.java
@@ -1,0 +1,61 @@
+package org.red5.server.stream.consumer;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.red5.server.net.rtmp.Channel;
+import org.red5.server.net.rtmp.RTMPMinaConnection;
+import org.red5.server.net.rtmp.event.VideoData;
+import org.red5.server.stream.message.RTMPMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestConnectionConsumer {
+
+    private final Logger log = LoggerFactory.getLogger(TestConnectionConsumer.class);
+
+    private RTMPMinaConnection connection;
+    private Channel channel;
+    private ConnectionConsumer underTest;
+
+    @Before
+    public void setUp() {
+        connection = new RTMPMinaConnection();
+        channel = new Channel(connection, 1);
+        underTest = new ConnectionConsumer(connection, channel, channel, channel);
+    }
+
+    @Test
+    public void testNegativeTimestampsAreRolledOver() {
+        log.debug("\n testNegativeTimestampsAreRolledOver");
+        VideoData videoData1 = new VideoData();
+        videoData1.setTimestamp(-1);
+        underTest.pushMessage(null, RTMPMessage.build(videoData1));
+
+        assertEquals(Integer.MAX_VALUE, videoData1.getTimestamp());
+
+        VideoData videoData2 = new VideoData();
+        videoData2.setTimestamp(Integer.MIN_VALUE);
+        underTest.pushMessage(null, RTMPMessage.build(videoData2));
+
+        assertEquals(0, videoData2.getTimestamp());
+    }
+
+    @Test
+    public void testPositiveTimestampsAreUnaffected() {
+        log.debug("\n testPositiveTimestampsAreUnaffected");
+        VideoData videoData1 = new VideoData();
+        videoData1.setTimestamp(0);
+        underTest.pushMessage(null, RTMPMessage.build(videoData1));
+
+        assertEquals(0, videoData1.getTimestamp());
+
+        VideoData videoData2 = new VideoData();
+        videoData2.setTimestamp(Integer.MAX_VALUE);
+        underTest.pushMessage(null, RTMPMessage.build(videoData2));
+
+        assertEquals(Integer.MAX_VALUE, videoData2.getTimestamp());
+    }
+
+}


### PR DESCRIPTION
This pull request is related to disccusions on the red5-client repository, issue [#44](https://github.com/Red5/red5-client/issues/44).

Unsigned timestamps between 2<sup>31</sup> and 2<sup>32</sup> -1, which Red5 misinterprets as negative signed integers between -2<sup>31</sup> and -1, are now rolled over to positive integers between 0 and 2<sup>31</sup> - 1. Instead of being discarded, RTMP messages with large timestamps are now sent downstream.

I have added some unit tests to cover this behaviour and have successfully tested the patch on our pre-production environment with a few different RTMP output destinations.

